### PR TITLE
typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Exceptional words with sufixes are also detected.
 
 ```js
 // This also works
-const latinWord = transliterator.toLatin('октябрда');
+const latinWord = transliterator.toLatin('октябрьда');
 console.log(latinWord); // -> 'oktabrda' (not 'oktyabrda')
 ```
 

--- a/README_UZ.md
+++ b/README_UZ.md
@@ -121,7 +121,7 @@ Istisnoli so‘zlar qo‘shimcha qo‘shilgan holatida ham to‘g‘ri o‘giril
 
 ```js
 // Bu ham ishlaydi
-const latinWord = transliterator.toLatin('октябрда');
+const latinWord = transliterator.toLatin('октябрьда');
 console.log(latinWord); // -> 'oktabrda' ('oktyabrda' emas)
 ```
 


### PR DESCRIPTION
In the docs the following code was provided:

```js
const latinWord = transliterator.toLatin('октябрда');
console.log(latinWord); // -> 'oktabrda' (not 'oktyabrda')
```
But it logged "oktyabrda" instead.

There was a typo in argument for toLatin invocation, because an exception provided earlier was:
```js
['oktabr', 'октябрь']
```